### PR TITLE
Use YACE defined interfaces for CloudWatch, Tagging, and Accounts

### DIFF
--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -12,9 +12,9 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	exporter "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/session"
 )
 
 const (
@@ -101,13 +101,13 @@ func NewYACEApp() *cli.App {
 		},
 		&cli.IntFlag{
 			Name:        "cloudwatch-concurrency",
-			Value:       exporter.DefaultCloudWatchAPIConcurrency,
+			Value:       clients.DefaultCloudWatchAPIConcurrency,
 			Usage:       "Maximum number of concurrent requests to CloudWatch API.",
 			Destination: &cloudwatchConcurrency,
 		},
 		&cli.IntFlag{
 			Name:        "tag-concurrency",
-			Value:       exporter.DefaultTaggingAPIConcurrency,
+			Value:       clients.DefaultTaggingAPIConcurrency,
 			Usage:       "Maximum number of concurrent requests to Resource Tagging API.",
 			Destination: &tagConcurrency,
 		},
@@ -191,7 +191,7 @@ func startScraper(c *cli.Context) error {
 	featureFlags := c.StringSlice(enableFeatureFlag)
 
 	s := NewScraper(featureFlags)
-	cache := session.NewSessionCache(cfg, fips, logger)
+	cache := clients.NewClientCache(cfg, fips, logger)
 
 	ctx, cancelRunningScrape := context.WithCancel(context.Background())
 	go s.decoupled(ctx, logger, cache)
@@ -233,8 +233,8 @@ func startScraper(c *cli.Context) error {
 			return
 		}
 
-		logger.Info("Reset session cache")
-		cache = session.NewSessionCache(cfg, fips, logger)
+		logger.Info("Reset clients cache")
+		cache = clients.NewClientCache(cfg, fips, logger)
 
 		cancelRunningScrape()
 		ctx, cancelRunningScrape = context.WithCancel(context.Background())

--- a/cmd/yace/scraper.go
+++ b/cmd/yace/scraper.go
@@ -9,8 +9,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	exporter "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/session"
 )
 
 type scraper struct {
@@ -34,7 +34,7 @@ func (s *scraper) makeHandler() func(http.ResponseWriter, *http.Request) {
 	}
 }
 
-func (s *scraper) decoupled(ctx context.Context, logger logging.Logger, cache session.SessionCache) {
+func (s *scraper) decoupled(ctx context.Context, logger logging.Logger, cache clients.ClientCache) {
 	logger.Debug("Starting scraping async")
 	s.scrape(ctx, logger, cache)
 
@@ -53,7 +53,7 @@ func (s *scraper) decoupled(ctx context.Context, logger logging.Logger, cache se
 	}
 }
 
-func (s *scraper) scrape(ctx context.Context, logger logging.Logger, cache session.SessionCache) {
+func (s *scraper) scrape(ctx context.Context, logger logging.Logger, cache clients.ClientCache) {
 	if !sem.TryAcquire(1) {
 		// This shouldn't happen under normal use, users should adjust their configuration when this occurs.
 		// Let them know by logging a warning.
@@ -78,8 +78,6 @@ func (s *scraper) scrape(ctx context.Context, logger logging.Logger, cache sessi
 		cache,
 		exporter.MetricsPerQuery(metricsPerQuery),
 		exporter.LabelsSnakeCase(labelsSnakeCase),
-		exporter.CloudWatchAPIConcurrency(cloudwatchConcurrency),
-		exporter.TaggingAPIConcurrency(tagConcurrency),
 		exporter.EnableFeatureFlag(s.featureFlags...),
 	)
 	if err != nil {

--- a/pkg/clients/account/client.go
+++ b/pkg/clients/account/client.go
@@ -1,0 +1,38 @@
+package account
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
+)
+
+type Client interface {
+	GetAccount(ctx context.Context) (string, error)
+}
+
+type client struct {
+	logger    logging.Logger
+	stsClient stsiface.STSAPI
+}
+
+func NewClient(logger logging.Logger, stsClient stsiface.STSAPI) Client {
+	return &client{
+		logger:    logger,
+		stsClient: stsClient,
+	}
+}
+
+func (c client) GetAccount(ctx context.Context) (string, error) {
+	result, err := c.stsClient.GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", err
+	}
+	if result.Account == nil {
+		return "", errors.New("aws sts GetCallerIdentityWithContext returned no account")
+	}
+	return *result.Account, nil
+}

--- a/pkg/clients/cache.go
+++ b/pkg/clients/cache.go
@@ -1,4 +1,4 @@
-package session
+package clients
 
 import (
 	"fmt"
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/aws/aws-sdk-go/service/databasemigrationservice"
 	"github.com/aws/aws-sdk-go/service/databasemigrationservice/databasemigrationserviceiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -24,39 +23,41 @@ import (
 	"github.com/aws/aws-sdk-go/service/prometheusservice"
 	"github.com/aws/aws-sdk-go/service/prometheusservice/prometheusserviceiface"
 	r "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
-	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 	"github.com/aws/aws-sdk-go/service/storagegateway/storagegatewayiface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/account"
+	cloudwatch_client "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/tagging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 )
 
-// SessionCache is an interface to a cache of sessions and clients for all the
+const (
+	DefaultCloudWatchAPIConcurrency = 5
+	DefaultTaggingAPIConcurrency    = 5
+)
+
+// ClientCache is an interface to a cache aws clients for all the
 // roles specified by the exporter. For jobs with many duplicate roles, this provides
 // relief to the AWS API and prevents timeouts by excessive credential requesting.
-type SessionCache interface { //nolint:revive
-	GetSTS(config.Role) stsiface.STSAPI
-	GetCloudwatch(*string, config.Role) cloudwatchiface.CloudWatchAPI
-	GetTagging(*string, config.Role) resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
-	GetASG(*string, config.Role) autoscalingiface.AutoScalingAPI
-	GetEC2(*string, config.Role) ec2iface.EC2API
-	GetDMS(*string, config.Role) databasemigrationserviceiface.DatabaseMigrationServiceAPI
-	GetAPIGateway(*string, config.Role) apigatewayiface.APIGatewayAPI
-	GetStorageGateway(*string, config.Role) storagegatewayiface.StorageGatewayAPI
-	GetPrometheus(*string, config.Role) prometheusserviceiface.PrometheusServiceAPI
+type ClientCache interface { //nolint:revive
+	GetCloudwatchClient(region string, role config.Role, concurrencyLimit int) cloudwatch_client.Client
+	GetTaggingClient(region string, role config.Role, concurrencyLimit int) tagging.Client
+	GetAccountClient(region string, role config.Role) account.Client
+
 	Refresh()
 	Clear()
 }
 
-type sessionCache struct {
+type clientCache struct {
 	stsRegion        string
 	session          *session.Session
 	endpointResolver endpoints.ResolverFunc
 	stscache         map[config.Role]stsiface.STSAPI
-	clients          map[config.Role]map[string]*clientCache
+	clients          map[config.Role]map[string]*clients
 	cleared          bool
 	refreshed        bool
 	mu               sync.Mutex
@@ -64,37 +65,32 @@ type sessionCache struct {
 	logger           logging.Logger
 }
 
-type clientCache struct {
+type clients struct {
 	// if we know that this job is only used for static
 	// then we don't have to construct as many cached connections
 	// later on
-	onlyStatic     bool
-	cloudwatch     cloudwatchiface.CloudWatchAPI
-	tagging        resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
-	asg            autoscalingiface.AutoScalingAPI
-	ec2            ec2iface.EC2API
-	prometheus     prometheusserviceiface.PrometheusServiceAPI
-	dms            databasemigrationserviceiface.DatabaseMigrationServiceAPI
-	apiGateway     apigatewayiface.APIGatewayAPI
-	storageGateway storagegatewayiface.StorageGatewayAPI
+	onlyStatic bool
+	cloudwatch cloudwatch_client.Client
+	tagging    tagging.Client
+	account    account.Client
 }
 
-// NewSessionCache creates a new session cache to use when fetching data from
+// NewClientCache creates a new clients cache to use when fetching data from
 // AWS.
-func NewSessionCache(cfg config.ScrapeConf, fips bool, logger logging.Logger) SessionCache {
+func NewClientCache(cfg config.ScrapeConf, fips bool, logger logging.Logger) ClientCache {
 	stscache := map[config.Role]stsiface.STSAPI{}
-	roleCache := map[config.Role]map[string]*clientCache{}
+	cache := map[config.Role]map[string]*clients{}
 
 	for _, discoveryJob := range cfg.Discovery.Jobs {
 		for _, role := range discoveryJob.Roles {
 			if _, ok := stscache[role]; !ok {
 				stscache[role] = nil
 			}
-			if _, ok := roleCache[role]; !ok {
-				roleCache[role] = map[string]*clientCache{}
+			if _, ok := cache[role]; !ok {
+				cache[role] = map[string]*clients{}
 			}
 			for _, region := range discoveryJob.Regions {
-				roleCache[role][region] = &clientCache{}
+				cache[role][region] = &clients{}
 			}
 		}
 	}
@@ -105,14 +101,14 @@ func NewSessionCache(cfg config.ScrapeConf, fips bool, logger logging.Logger) Se
 				stscache[role] = nil
 			}
 
-			if _, ok := roleCache[role]; !ok {
-				roleCache[role] = map[string]*clientCache{}
+			if _, ok := cache[role]; !ok {
+				cache[role] = map[string]*clients{}
 			}
 
 			for _, region := range staticJob.Regions {
 				// Only write a new region in if the region does not exist
-				if _, ok := roleCache[role][region]; !ok {
-					roleCache[role][region] = &clientCache{
+				if _, ok := cache[role][region]; !ok {
+					cache[role][region] = &clients{
 						onlyStatic: true,
 					}
 				}
@@ -126,14 +122,14 @@ func NewSessionCache(cfg config.ScrapeConf, fips bool, logger logging.Logger) Se
 				stscache[role] = nil
 			}
 
-			if _, ok := roleCache[role]; !ok {
-				roleCache[role] = map[string]*clientCache{}
+			if _, ok := cache[role]; !ok {
+				cache[role] = map[string]*clients{}
 			}
 
 			for _, region := range customNamespaceJob.Regions {
 				// Only write a new region in if the region does not exist
-				if _, ok := roleCache[role][region]; !ok {
-					roleCache[role][region] = &clientCache{
+				if _, ok := cache[role][region]; !ok {
+					cache[role][region] = &clients{
 						onlyStatic: true,
 					}
 				}
@@ -153,12 +149,12 @@ func NewSessionCache(cfg config.ScrapeConf, fips bool, logger logging.Logger) Se
 		}
 	}
 
-	return &sessionCache{
+	return &clientCache{
 		stsRegion:        cfg.StsRegion,
 		session:          nil,
 		endpointResolver: endpointResolver,
 		stscache:         stscache,
-		clients:          roleCache,
+		clients:          cache,
 		fips:             fips,
 		cleared:          false,
 		refreshed:        false,
@@ -168,192 +164,128 @@ func NewSessionCache(cfg config.ScrapeConf, fips bool, logger logging.Logger) Se
 
 // Refresh and Clear help to avoid using lock primitives by asserting that
 // there are no ongoing writes to the map.
-func (s *sessionCache) Clear() {
-	if s.cleared {
+func (c *clientCache) Clear() {
+	if c.cleared {
 		return
 	}
 
-	for role := range s.stscache {
-		s.stscache[role] = nil
+	for role := range c.stscache {
+		c.stscache[role] = nil
 	}
 
-	for role, regions := range s.clients {
+	for role, regions := range c.clients {
 		for region := range regions {
-			s.clients[role][region].cloudwatch = nil
-			s.clients[role][region].tagging = nil
-			s.clients[role][region].asg = nil
-			s.clients[role][region].ec2 = nil
-			s.clients[role][region].prometheus = nil
-			s.clients[role][region].dms = nil
-			s.clients[role][region].apiGateway = nil
-			s.clients[role][region].storageGateway = nil
+			cachedClient := c.clients[role][region]
+			cachedClient.account = nil
+			cachedClient.cloudwatch = nil
+			cachedClient.tagging = nil
 		}
 	}
-	s.cleared = true
-	s.refreshed = false
+	c.cleared = true
+	c.refreshed = false
 }
 
-func (s *sessionCache) Refresh() {
-	// TODO: make all the getter functions atomic pointer loads and sets
-	if s.refreshed {
+func (c *clientCache) Refresh() {
+	if c.refreshed {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Double check Refresh wasn't called concurrently
+	if c.refreshed {
 		return
 	}
 
 	// sessions really only need to be constructed once at runtime
-	if s.session == nil {
-		s.session = createAWSSession(s.endpointResolver, s.logger.IsDebugEnabled())
+	if c.session == nil {
+		c.session = createAWSSession(c.endpointResolver, c.logger.IsDebugEnabled())
 	}
 
-	for role := range s.stscache {
-		s.stscache[role] = createStsSession(s.session, role, s.stsRegion, s.fips, s.logger.IsDebugEnabled())
+	for role := range c.stscache {
+		c.stscache[role] = createStsSession(c.session, role, c.stsRegion, c.fips, c.logger.IsDebugEnabled())
 	}
 
-	for role, regions := range s.clients {
+	for role, regions := range c.clients {
 		for region := range regions {
+			cachedClient := c.clients[role][region]
 			// if the role is just used in static jobs, then we
 			// can skip creating other sessions and potentially running
 			// into permissions errors or taking up needless cycles
-			s.clients[role][region].cloudwatch = createCloudwatchSession(s.session, &region, role, s.fips, s.logger.IsDebugEnabled())
-			if s.clients[role][region].onlyStatic {
+			cachedClient.cloudwatch = createCloudWatchClient(c.session, &region, role, c.fips, c.logger)
+			if cachedClient.onlyStatic {
 				continue
 			}
-
-			s.clients[role][region].tagging = createTagSession(s.session, &region, role, s.logger.IsDebugEnabled())
-			s.clients[role][region].asg = createASGSession(s.session, &region, role, s.logger.IsDebugEnabled())
-			s.clients[role][region].ec2 = createEC2Session(s.session, &region, role, s.fips, s.logger.IsDebugEnabled())
-			s.clients[role][region].dms = createDMSSession(s.session, &region, role, s.fips, s.logger.IsDebugEnabled())
-			s.clients[role][region].apiGateway = createAPIGatewaySession(s.session, &region, role, s.fips, s.logger.IsDebugEnabled())
-			s.clients[role][region].storageGateway = createStorageGatewaySession(s.session, &region, role, s.fips, s.logger.IsDebugEnabled())
-			s.clients[role][region].prometheus = createPrometheusSession(s.session, &region, role, s.fips, s.logger.IsDebugEnabled())
+			cachedClient.tagging = createTaggingClient(c.session, &region, role, c.fips, c.logger)
+			cachedClient.account = createAccountClient(c.logger, c.stscache[role])
 		}
 	}
 
-	s.cleared = false
-	s.refreshed = true
+	c.cleared = false
+	c.refreshed = true
 }
 
-func (s *sessionCache) GetSTS(role config.Role) stsiface.STSAPI {
-	// if we have not refreshed then we need to lock in case we are accessing concurrently
-	if !s.refreshed {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-	}
-	if sess, ok := s.stscache[role]; ok && sess != nil {
-		return sess
-	}
-	s.stscache[role] = createStsSession(s.session, role, s.stsRegion, s.fips, s.logger.IsDebugEnabled())
-	return s.stscache[role]
+func createCloudWatchClient(s *session.Session, region *string, role config.Role, fips bool, logger logging.Logger) cloudwatch_client.Client {
+	return cloudwatch_client.NewClient(
+		logger,
+		createCloudwatchSession(s, region, role, fips, logger.IsDebugEnabled()),
+	)
 }
 
-func (s *sessionCache) GetCloudwatch(region *string, role config.Role) cloudwatchiface.CloudWatchAPI {
-	// if we have not refreshed then we need to lock in case we are accessing concurrently
-	if !s.refreshed {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-	}
-	if sess, ok := s.clients[role][*region]; ok && sess.cloudwatch != nil {
-		return sess.cloudwatch
-	}
-	s.clients[role][*region].cloudwatch = createCloudwatchSession(s.session, region, role, s.fips, s.logger.IsDebugEnabled())
-	return s.clients[role][*region].cloudwatch
+func createTaggingClient(session *session.Session, region *string, role config.Role, fips bool, logger logging.Logger) tagging.Client {
+	return tagging.NewClient(
+		logger,
+		createTagSession(session, region, role, logger.IsDebugEnabled()),
+		createASGSession(session, region, role, logger.IsDebugEnabled()),
+		createAPIGatewaySession(session, region, role, fips, logger.IsDebugEnabled()),
+		createEC2Session(session, region, role, fips, logger.IsDebugEnabled()),
+		createDMSSession(session, region, role, fips, logger.IsDebugEnabled()),
+		createPrometheusSession(session, region, role, fips, logger.IsDebugEnabled()),
+		createStorageGatewaySession(session, region, role, fips, logger.IsDebugEnabled()),
+	)
 }
 
-func (s *sessionCache) GetTagging(region *string, role config.Role) resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI {
-	// if we have not refreshed then we need to lock in case we are accessing concurrently
-	if !s.refreshed {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-	}
-	if sess, ok := s.clients[role][*region]; ok && sess.tagging != nil {
-		return sess.tagging
-	}
-
-	s.clients[role][*region].tagging = createTagSession(s.session, region, role, s.fips)
-	return s.clients[role][*region].tagging
+func createAccountClient(logger logging.Logger, sts stsiface.STSAPI) account.Client {
+	return account.NewClient(logger, sts)
 }
 
-func (s *sessionCache) GetASG(region *string, role config.Role) autoscalingiface.AutoScalingAPI {
-	// if we have not refreshed then we need to lock in case we are accessing concurrently
-	if !s.refreshed {
-		s.mu.Lock()
-		defer s.mu.Unlock()
+func (c *clientCache) GetCloudwatchClient(region string, role config.Role, concurrencyLimit int) cloudwatch_client.Client {
+	if !c.refreshed {
+		// if we have not refreshed then we need to lock in case we are accessing concurrently
+		c.mu.Lock()
+		defer c.mu.Unlock()
 	}
-	if sess, ok := s.clients[role][*region]; ok && sess.asg != nil {
-		return sess.asg
+	if client := c.clients[role][region].cloudwatch; client != nil {
+		return cloudwatch_client.NewLimitedConcurrencyClient(client, concurrencyLimit)
 	}
-
-	s.clients[role][*region].asg = createASGSession(s.session, region, role, s.fips)
-	return s.clients[role][*region].asg
+	c.clients[role][region].cloudwatch = createCloudWatchClient(c.session, &region, role, c.fips, c.logger)
+	return cloudwatch_client.NewLimitedConcurrencyClient(c.clients[role][region].cloudwatch, concurrencyLimit)
 }
 
-func (s *sessionCache) GetEC2(region *string, role config.Role) ec2iface.EC2API {
-	// if we have not refreshed then we need to lock in case we are accessing concurrently
-	if !s.refreshed {
-		s.mu.Lock()
-		defer s.mu.Unlock()
+func (c *clientCache) GetTaggingClient(region string, role config.Role, concurrencyLimit int) tagging.Client {
+	if !c.refreshed {
+		// if we have not refreshed then we need to lock in case we are accessing concurrently
+		c.mu.Lock()
+		defer c.mu.Unlock()
 	}
-	if sess, ok := s.clients[role][*region]; ok && sess.ec2 != nil {
-		return sess.ec2
+	if client := c.clients[role][region].tagging; client != nil {
+		return tagging.NewLimitedConcurrencyClient(client, concurrencyLimit)
 	}
-
-	s.clients[role][*region].ec2 = createEC2Session(s.session, region, role, s.fips, s.logger.IsDebugEnabled())
-	return s.clients[role][*region].ec2
+	c.clients[role][region].tagging = createTaggingClient(c.session, &region, role, c.fips, c.logger)
+	return tagging.NewLimitedConcurrencyClient(c.clients[role][region].tagging, concurrencyLimit)
 }
 
-func (s *sessionCache) GetPrometheus(region *string, role config.Role) prometheusserviceiface.PrometheusServiceAPI {
-	// if we have not refreshed then we need to lock in case we are accessing concurrently
-	if !s.refreshed {
-		s.mu.Lock()
-		defer s.mu.Unlock()
+func (c *clientCache) GetAccountClient(region string, role config.Role) account.Client {
+	if !c.refreshed {
+		// if we have not refreshed then we need to lock in case we are accessing concurrently
+		c.mu.Lock()
+		defer c.mu.Unlock()
 	}
-	if sess, ok := s.clients[role][*region]; ok && sess.prometheus != nil {
-		return sess.prometheus
+	if client := c.clients[role][region].account; client != nil {
+		return client
 	}
-
-	s.clients[role][*region].prometheus = createPrometheusSession(s.session, region, role, s.fips, s.logger.IsDebugEnabled())
-	return s.clients[role][*region].prometheus
-}
-
-func (s *sessionCache) GetDMS(region *string, role config.Role) databasemigrationserviceiface.DatabaseMigrationServiceAPI {
-	// if we have not refreshed then we need to lock in case we are accessing concurrently
-	if !s.refreshed {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-	}
-	if sess, ok := s.clients[role][*region]; ok && sess.dms != nil {
-		return sess.dms
-	}
-
-	s.clients[role][*region].dms = createDMSSession(s.session, region, role, s.fips, s.logger.IsDebugEnabled())
-	return s.clients[role][*region].dms
-}
-
-func (s *sessionCache) GetAPIGateway(region *string, role config.Role) apigatewayiface.APIGatewayAPI {
-	// if we have not refreshed then we need to lock in case we are accessing concurrently
-	if !s.refreshed {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-	}
-	if sess, ok := s.clients[role][*region]; ok && sess.apiGateway != nil {
-		return sess.apiGateway
-	}
-
-	s.clients[role][*region].apiGateway = createAPIGatewaySession(s.session, region, role, s.fips, s.logger.IsDebugEnabled())
-	return s.clients[role][*region].apiGateway
-}
-
-func (s *sessionCache) GetStorageGateway(region *string, role config.Role) storagegatewayiface.StorageGatewayAPI {
-	// if we have not refreshed then we need to lock in case we are accessing concurrently
-	if !s.refreshed {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-	}
-	if sess, ok := s.clients[role][*region]; ok && sess.storageGateway != nil {
-		return sess.storageGateway
-	}
-
-	s.clients[role][*region].storageGateway = createStorageGatewaySession(s.session, region, role, s.fips, s.logger.IsDebugEnabled())
-	return s.clients[role][*region].storageGateway
+	c.clients[role][region].account = createAccountClient(c.logger, c.stscache[role])
+	return c.clients[role][region].account
 }
 
 func setExternalID(ID string) func(p *stscreds.AssumeRoleProvider) {

--- a/pkg/clients/cache_test.go
+++ b/pkg/clients/cache_test.go
@@ -1,4 +1,4 @@
-package session
+package clients
 
 import (
 	"fmt"
@@ -16,7 +16,7 @@ import (
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 )
 
-func cmpCache(t *testing.T, initialCache *sessionCache, cache *sessionCache) {
+func cmpCache(t *testing.T, initialCache *clientCache, cache *clientCache) {
 	for role := range initialCache.stscache {
 		if _, ok := cache.stscache[role]; !ok {
 			t.Logf("`role` not in sts cache %s", role.RoleArn)
@@ -57,24 +57,24 @@ func cmpCache(t *testing.T, initialCache *sessionCache, cache *sessionCache) {
 	}
 }
 
-func TestNewSessionCache(t *testing.T) {
+func TestNewClientCache(t *testing.T) {
 	tests := []struct {
 		descrip string
 		config  config.ScrapeConf
 		fips    bool
-		cache   *sessionCache
+		cache   *clientCache
 	}{
 		{
 			"an empty config gives an empty cache",
 			config.ScrapeConf{},
 			false,
-			&sessionCache{logger: logging.NewNopLogger()},
+			&clientCache{logger: logging.NewNopLogger()},
 		},
 		{
-			"if fips is set then the session has fips",
+			"if fips is set then the clients has fips",
 			config.ScrapeConf{},
 			true,
-			&sessionCache{
+			&clientCache{
 				fips:   true,
 				logger: logging.NewNopLogger(),
 			},
@@ -114,31 +114,31 @@ func TestNewSessionCache(t *testing.T) {
 				},
 			},
 			false,
-			&sessionCache{
+			&clientCache{
 				stscache: map[config.Role]stsiface.STSAPI{
 					{RoleArn: "some-arn"}:                      nil,
 					{RoleArn: "some-arn", ExternalID: "thing"}: nil,
 					{RoleArn: "some-arn2"}:                     nil,
 					{RoleArn: "some-arn5"}:                     nil,
 				},
-				clients: map[config.Role]map[string]*clientCache{
+				clients: map[config.Role]map[string]*clients{
 					{RoleArn: "some-arn"}: {
-						"ap-northeast-3": &clientCache{},
-						"us-east-1":      &clientCache{},
-						"us-west-2":      &clientCache{},
+						"ap-northeast-3": &clients{},
+						"us-east-1":      &clients{},
+						"us-west-2":      &clients{},
 					},
 					{RoleArn: "some-arn", ExternalID: "thing"}: {
-						"ap-northeast-3": &clientCache{},
-						"us-east-1":      &clientCache{},
-						"us-west-2":      &clientCache{},
+						"ap-northeast-3": &clients{},
+						"us-east-1":      &clients{},
+						"us-west-2":      &clients{},
 					},
 					{RoleArn: "some-arn2"}: {
-						"ap-northeast-3": &clientCache{},
-						"us-east-1":      &clientCache{},
-						"us-west-2":      &clientCache{},
+						"ap-northeast-3": &clients{},
+						"us-east-1":      &clients{},
+						"us-west-2":      &clients{},
 					},
 					{RoleArn: "some-arn5"}: {
-						"ap-northeast-3": &clientCache{},
+						"ap-northeast-3": &clients{},
 					},
 				},
 				logger: logging.NewNopLogger(),
@@ -197,7 +197,7 @@ func TestNewSessionCache(t *testing.T) {
 				},
 			},
 			false,
-			&sessionCache{
+			&clientCache{
 				stscache: map[config.Role]stsiface.STSAPI{
 					{RoleArn: "some-arn"}:                      nil,
 					{RoleArn: "some-arn", ExternalID: "thing"}: nil,
@@ -205,26 +205,26 @@ func TestNewSessionCache(t *testing.T) {
 					{RoleArn: "some-arn3"}:                     nil,
 					{RoleArn: "some-arn4"}:                     nil,
 				},
-				clients: map[config.Role]map[string]*clientCache{
+				clients: map[config.Role]map[string]*clients{
 					{RoleArn: "some-arn"}: {
-						"ap-northeast-1": &clientCache{onlyStatic: true},
-						"eu-west-2":      &clientCache{onlyStatic: true},
-						"us-east-1":      &clientCache{onlyStatic: true},
+						"ap-northeast-1": &clients{onlyStatic: true},
+						"eu-west-2":      &clients{onlyStatic: true},
+						"us-east-1":      &clients{onlyStatic: true},
 					},
 					{RoleArn: "some-arn", ExternalID: "thing"}: {
-						"us-east-1": &clientCache{onlyStatic: true},
+						"us-east-1": &clients{onlyStatic: true},
 					},
 					{RoleArn: "some-arn2"}: {
-						"ap-northeast-1": &clientCache{onlyStatic: true},
-						"eu-west-2":      &clientCache{onlyStatic: true},
-						"us-east-1":      &clientCache{onlyStatic: true},
+						"ap-northeast-1": &clients{onlyStatic: true},
+						"eu-west-2":      &clients{onlyStatic: true},
+						"us-east-1":      &clients{onlyStatic: true},
 					},
 					{RoleArn: "some-arn3"}: {
-						"eu-west-2": &clientCache{onlyStatic: true},
-						"us-east-1": &clientCache{onlyStatic: true},
+						"eu-west-2": &clients{onlyStatic: true},
+						"us-east-1": &clients{onlyStatic: true},
 					},
 					{RoleArn: "some-arn4"}: {
-						"ap-northeast-1": &clientCache{onlyStatic: true},
+						"ap-northeast-1": &clients{onlyStatic: true},
 					},
 				},
 				logger: logging.NewNopLogger(),
@@ -312,7 +312,7 @@ func TestNewSessionCache(t *testing.T) {
 				},
 			},
 			false,
-			&sessionCache{
+			&clientCache{
 				stscache: map[config.Role]stsiface.STSAPI{
 					{RoleArn: "some-arn"}:                      nil,
 					{RoleArn: "some-arn", ExternalID: "thing"}: nil,
@@ -321,35 +321,35 @@ func TestNewSessionCache(t *testing.T) {
 					{RoleArn: "some-arn4"}:                     nil,
 					{RoleArn: "some-arn5"}:                     nil,
 				},
-				clients: map[config.Role]map[string]*clientCache{
+				clients: map[config.Role]map[string]*clients{
 					{RoleArn: "some-arn"}: {
-						"ap-northeast-3": &clientCache{},
-						"us-east-1":      &clientCache{},
-						"ap-northeast-1": &clientCache{onlyStatic: true},
-						"eu-west-2":      &clientCache{onlyStatic: true},
-						"us-west-2":      &clientCache{},
+						"ap-northeast-3": &clients{},
+						"us-east-1":      &clients{},
+						"ap-northeast-1": &clients{onlyStatic: true},
+						"eu-west-2":      &clients{onlyStatic: true},
+						"us-west-2":      &clients{},
 					},
 					{RoleArn: "some-arn", ExternalID: "thing"}: {
-						"us-east-1": &clientCache{onlyStatic: true},
+						"us-east-1": &clients{onlyStatic: true},
 					},
 					{RoleArn: "some-arn2"}: {
-						"ap-northeast-3": &clientCache{},
-						"ap-northeast-1": &clientCache{onlyStatic: true},
-						"eu-west-2":      &clientCache{onlyStatic: true},
-						"us-east-1":      &clientCache{},
-						"us-west-2":      &clientCache{},
+						"ap-northeast-3": &clients{},
+						"ap-northeast-1": &clients{onlyStatic: true},
+						"eu-west-2":      &clients{onlyStatic: true},
+						"us-east-1":      &clients{},
+						"us-west-2":      &clients{},
 					},
 					{RoleArn: "some-arn3"}: {
-						"ap-northeast-3": &clientCache{},
-						"eu-west-2":      &clientCache{onlyStatic: true},
-						"us-east-1":      &clientCache{},
-						"us-west-2":      &clientCache{},
+						"ap-northeast-3": &clients{},
+						"eu-west-2":      &clients{onlyStatic: true},
+						"us-east-1":      &clients{},
+						"us-west-2":      &clients{},
 					},
 					{RoleArn: "some-arn4"}: {
-						"ap-northeast-1": &clientCache{onlyStatic: true},
+						"ap-northeast-1": &clients{onlyStatic: true},
 					},
 					{RoleArn: "some-arn5"}: {
-						"ap-northeast-3": &clientCache{},
+						"ap-northeast-3": &clients{},
 					},
 				},
 				logger: logging.NewNopLogger(),
@@ -411,7 +411,7 @@ func TestNewSessionCache(t *testing.T) {
 				},
 			},
 			false,
-			&sessionCache{
+			&clientCache{
 				stscache: map[config.Role]stsiface.STSAPI{
 					{RoleArn: "some-arn"}:                      nil,
 					{RoleArn: "some-arn", ExternalID: "thing"}: nil,
@@ -419,26 +419,26 @@ func TestNewSessionCache(t *testing.T) {
 					{RoleArn: "some-arn3"}:                     nil,
 					{RoleArn: "some-arn4"}:                     nil,
 				},
-				clients: map[config.Role]map[string]*clientCache{
+				clients: map[config.Role]map[string]*clients{
 					{RoleArn: "some-arn"}: {
-						"ap-northeast-1": &clientCache{onlyStatic: true},
-						"eu-west-2":      &clientCache{onlyStatic: true},
-						"us-east-1":      &clientCache{onlyStatic: true},
+						"ap-northeast-1": &clients{onlyStatic: true},
+						"eu-west-2":      &clients{onlyStatic: true},
+						"us-east-1":      &clients{onlyStatic: true},
 					},
 					{RoleArn: "some-arn", ExternalID: "thing"}: {
-						"us-east-1": &clientCache{onlyStatic: true},
+						"us-east-1": &clients{onlyStatic: true},
 					},
 					{RoleArn: "some-arn2"}: {
-						"ap-northeast-1": &clientCache{onlyStatic: true},
-						"eu-west-2":      &clientCache{onlyStatic: true},
-						"us-east-1":      &clientCache{onlyStatic: true},
+						"ap-northeast-1": &clients{onlyStatic: true},
+						"eu-west-2":      &clients{onlyStatic: true},
+						"us-east-1":      &clients{onlyStatic: true},
 					},
 					{RoleArn: "some-arn3"}: {
-						"eu-west-2": &clientCache{onlyStatic: true},
-						"us-east-1": &clientCache{onlyStatic: true},
+						"eu-west-2": &clients{onlyStatic: true},
+						"us-east-1": &clients{onlyStatic: true},
 					},
 					{RoleArn: "some-arn4"}: {
-						"ap-northeast-1": &clientCache{onlyStatic: true},
+						"ap-northeast-1": &clients{onlyStatic: true},
 					},
 				},
 				logger: logging.NewNopLogger(),
@@ -450,7 +450,7 @@ func TestNewSessionCache(t *testing.T) {
 		test := l
 		t.Run(test.descrip, func(t *testing.T) {
 			t.Parallel()
-			cache := NewSessionCache(test.config, test.fips, logging.NewNopLogger()).(*sessionCache)
+			cache := NewClientCache(test.config, test.fips, logging.NewNopLogger()).(*clientCache)
 			t.Logf("the cache is: %v", cache)
 
 			if test.cache.cleared != cache.cleared {
@@ -480,30 +480,25 @@ func TestClear(t *testing.T) {
 	role := config.Role{}
 
 	tests := []struct {
-		descrip string
-		cache   *sessionCache
+		description string
+		cache       *clientCache
 	}{
 		{
 			"a new clear clears all clients",
-			&sessionCache{
+			&clientCache{
 				session: mock.Session,
 				cleared: false,
 				mu:      sync.Mutex{},
 				stscache: map[config.Role]stsiface.STSAPI{
 					{}: nil,
 				},
-				clients: map[config.Role]map[string]*clientCache{
+				clients: map[config.Role]map[string]*clients{
 					{}: {
-						"us-east-1": &clientCache{
-							cloudwatch:     createCloudwatchSession(mock.Session, &region, role, false, false),
-							tagging:        createTagSession(mock.Session, &region, role, false),
-							asg:            createASGSession(mock.Session, &region, role, false),
-							ec2:            createEC2Session(mock.Session, &region, role, false, false),
-							dms:            createDMSSession(mock.Session, &region, role, false, false),
-							apiGateway:     createAPIGatewaySession(mock.Session, &region, role, false, false),
-							storageGateway: createStorageGatewaySession(mock.Session, &region, role, false, false),
-							prometheus:     createPrometheusSession(mock.Session, &region, role, false, false),
-							onlyStatic:     true,
+						"us-east-1": &clients{
+							cloudwatch: createCloudWatchClient(mock.Session, &region, role, false, logging.NewNopLogger()),
+							tagging:    createTaggingClient(mock.Session, &region, role, false, logging.NewNopLogger()),
+							account:    createAccountClient(logging.NewNopLogger(), nil),
+							onlyStatic: true,
 						},
 					},
 				},
@@ -512,23 +507,19 @@ func TestClear(t *testing.T) {
 		},
 		{
 			"A second call to clear does nothing",
-			&sessionCache{
+			&clientCache{
 				cleared: true,
 				mu:      sync.Mutex{},
 				session: mock.Session,
 				stscache: map[config.Role]stsiface.STSAPI{
 					{}: nil,
 				},
-				clients: map[config.Role]map[string]*clientCache{
+				clients: map[config.Role]map[string]*clients{
 					{}: {
-						"us-east-1": &clientCache{
-							cloudwatch:     nil,
-							tagging:        nil,
-							asg:            nil,
-							ec2:            nil,
-							apiGateway:     nil,
-							storageGateway: nil,
-							prometheus:     nil,
+						"us-east-1": &clients{
+							cloudwatch: nil,
+							tagging:    nil,
+							account:    nil,
 						},
 					},
 				},
@@ -539,7 +530,7 @@ func TestClear(t *testing.T) {
 
 	for _, l := range tests {
 		test := l
-		t.Run(test.descrip, func(t *testing.T) {
+		t.Run(test.description, func(t *testing.T) {
 			test.cache.Clear()
 			if !test.cache.cleared {
 				t.Log("Cache cleared flag not set")
@@ -567,28 +558,8 @@ func TestClear(t *testing.T) {
 						t.Logf("`tagging client` %v in region %v is not nil", role, region)
 						t.Fail()
 					}
-					if client.asg != nil {
+					if client.account != nil {
 						t.Logf("`asg client` %v in region %v is not nil", role, region)
-						t.Fail()
-					}
-					if client.ec2 != nil {
-						t.Logf("`ec2 client` %v in region %v is not nil", role, region)
-						t.Fail()
-					}
-					if client.prometheus != nil {
-						t.Logf("`Prometheus client` %v in region %v is not nil", role, region)
-						t.Fail()
-					}
-					if client.dms != nil {
-						t.Logf("`dms client` %v in region %v is not nil", role, region)
-						t.Fail()
-					}
-					if client.apiGateway != nil {
-						t.Logf("`apiGateway client` %v in region %v is not nil", role, region)
-						t.Fail()
-					}
-					if client.storageGateway != nil {
-						t.Logf("`storageGateway client` %v in region %v is not nil", role, region)
 						t.Fail()
 					}
 				}
@@ -603,29 +574,24 @@ func TestRefresh(t *testing.T) {
 
 	tests := []struct {
 		descrip    string
-		cache      *sessionCache
+		cache      *clientCache
 		cloudwatch bool
 	}{
 		{
 			"a new refresh creates clients",
-			&sessionCache{
+			&clientCache{
 				session:   mock.Session,
 				refreshed: false,
 				mu:        sync.Mutex{},
 				stscache: map[config.Role]stsiface.STSAPI{
 					{}: nil,
 				},
-				clients: map[config.Role]map[string]*clientCache{
+				clients: map[config.Role]map[string]*clients{
 					{}: {
-						"us-east-1": &clientCache{
-							cloudwatch:     nil,
-							tagging:        nil,
-							asg:            nil,
-							ec2:            nil,
-							dms:            nil,
-							apiGateway:     nil,
-							storageGateway: nil,
-							prometheus:     nil,
+						"us-east-1": &clients{
+							cloudwatch: nil,
+							tagging:    nil,
+							account:    nil,
 						},
 					},
 				},
@@ -635,25 +601,20 @@ func TestRefresh(t *testing.T) {
 		},
 		{
 			"a new refresh with static only creates only cloudwatch",
-			&sessionCache{
+			&clientCache{
 				session:   mock.Session,
 				refreshed: false,
 				mu:        sync.Mutex{},
 				stscache: map[config.Role]stsiface.STSAPI{
 					{}: nil,
 				},
-				clients: map[config.Role]map[string]*clientCache{
+				clients: map[config.Role]map[string]*clients{
 					{}: {
-						"us-east-1": &clientCache{
-							cloudwatch:     nil,
-							tagging:        nil,
-							asg:            nil,
-							ec2:            nil,
-							dms:            nil,
-							apiGateway:     nil,
-							storageGateway: nil,
-							prometheus:     nil,
-							onlyStatic:     true,
+						"us-east-1": &clients{
+							cloudwatch: nil,
+							tagging:    nil,
+							account:    nil,
+							onlyStatic: true,
 						},
 					},
 				},
@@ -663,24 +624,19 @@ func TestRefresh(t *testing.T) {
 		},
 		{
 			"A second call to refreshed does nothing",
-			&sessionCache{
+			&clientCache{
 				refreshed: true,
 				mu:        sync.Mutex{},
 				session:   mock.Session,
 				stscache: map[config.Role]stsiface.STSAPI{
 					{}: createStsSession(mock.Session, role, "", false, false),
 				},
-				clients: map[config.Role]map[string]*clientCache{
+				clients: map[config.Role]map[string]*clients{
 					{}: {
-						"us-east-1": &clientCache{
-							cloudwatch:     createCloudwatchSession(mock.Session, &region, role, false, false),
-							tagging:        createTagSession(mock.Session, &region, role, false),
-							asg:            createASGSession(mock.Session, &region, role, false),
-							ec2:            createEC2Session(mock.Session, &region, role, false, false),
-							dms:            createDMSSession(mock.Session, &region, role, false, false),
-							apiGateway:     createAPIGatewaySession(mock.Session, &region, role, false, false),
-							storageGateway: createStorageGatewaySession(mock.Session, &region, role, false, false),
-							prometheus:     createPrometheusSession(mock.Session, &region, role, false, false),
+						"us-east-1": &clients{
+							cloudwatch: createCloudWatchClient(mock.Session, &region, role, false, logging.NewNopLogger()),
+							tagging:    createTaggingClient(mock.Session, &region, role, false, logging.NewNopLogger()),
+							account:    createAccountClient(logging.NewNopLogger(), createStsSession(mock.Session, role, "", false, false)),
 						},
 					},
 				},
@@ -726,28 +682,8 @@ func TestRefresh(t *testing.T) {
 						t.Logf("`tagging client` %v in region %v still nil", role, region)
 						t.Fail()
 					}
-					if client.asg == nil {
+					if client.account == nil {
 						t.Logf("`asg client` %v in region %v still nil", role, region)
-						t.Fail()
-					}
-					if client.ec2 == nil {
-						t.Logf("`ec2 client` %v in region %v still nil", role, region)
-						t.Fail()
-					}
-					if client.prometheus == nil {
-						t.Logf("`prometheus client` %v in region %v still nil", role, region)
-						t.Fail()
-					}
-					if client.dms == nil {
-						t.Logf("`dms client` %v in region %v still nil", role, region)
-						t.Fail()
-					}
-					if client.apiGateway == nil {
-						t.Logf("`apiGateway client` %v in region %v still nil", role, region)
-						t.Fail()
-					}
-					if client.storageGateway == nil {
-						t.Logf("`storageGateway client` %v in region %v still nil", role, region)
 						t.Fail()
 					}
 				}
@@ -756,23 +692,11 @@ func TestRefresh(t *testing.T) {
 	}
 }
 
-func TestSessionCacheGetSTS(t *testing.T) {
-	testGetAWSClient(
-		t, "STS",
-		func(t *testing.T, cache *sessionCache, region *string, role config.Role) {
-			iface := cache.GetSTS(role)
-			if iface == nil {
-				t.Fail()
-				return
-			}
-		})
-}
-
-func TestSessionCacheGetCloudwatch(t *testing.T) {
+func TestClientCacheGetCloudwatchClient(t *testing.T) {
 	testGetAWSClient(
 		t, "Cloudwatch",
-		func(t *testing.T, cache *sessionCache, region *string, role config.Role) {
-			iface := cache.GetCloudwatch(region, role)
+		func(t *testing.T, cache *clientCache, region string, role config.Role) {
+			iface := cache.GetCloudwatchClient(region, role)
 			if iface == nil {
 				t.Fail()
 				return
@@ -780,11 +704,11 @@ func TestSessionCacheGetCloudwatch(t *testing.T) {
 		})
 }
 
-func TestSessionCacheGetTagging(t *testing.T) {
+func TestClientCacheGetTagging(t *testing.T) {
 	testGetAWSClient(
 		t, "Tagging",
-		func(t *testing.T, cache *sessionCache, region *string, role config.Role) {
-			iface := cache.GetTagging(region, role)
+		func(t *testing.T, cache *clientCache, region string, role config.Role) {
+			iface := cache.GetTaggingClient(region, role)
 			if iface == nil {
 				t.Fail()
 				return
@@ -792,59 +716,11 @@ func TestSessionCacheGetTagging(t *testing.T) {
 		})
 }
 
-func TestSessionCacheGetASG(t *testing.T) {
+func TestClientCacheGetAccount(t *testing.T) {
 	testGetAWSClient(
-		t, "ASG",
-		func(t *testing.T, cache *sessionCache, region *string, role config.Role) {
-			iface := cache.GetASG(region, role)
-			if iface == nil {
-				t.Fail()
-				return
-			}
-		})
-}
-
-func TestSessionCacheGetEC2(t *testing.T) {
-	testGetAWSClient(
-		t, "EC2",
-		func(t *testing.T, cache *sessionCache, region *string, role config.Role) {
-			iface := cache.GetEC2(region, role)
-			if iface == nil {
-				t.Fail()
-				return
-			}
-		})
-}
-
-func TestSessionCacheGetPrometheus(t *testing.T) {
-	testGetAWSClient(
-		t, "Prometheus",
-		func(t *testing.T, cache *sessionCache, region *string, role config.Role) {
-			iface := cache.GetPrometheus(region, role)
-			if iface == nil {
-				t.Fail()
-				return
-			}
-		})
-}
-
-func TestSessionCacheGetDMS(t *testing.T) {
-	testGetAWSClient(
-		t, "DMS",
-		func(t *testing.T, cache *sessionCache, region *string, role config.Role) {
-			iface := cache.GetDMS(region, role)
-			if iface == nil {
-				t.Fail()
-				return
-			}
-		})
-}
-
-func TestSessionCacheGetAPIGateway(t *testing.T) {
-	testGetAWSClient(
-		t, "APIGateway",
-		func(t *testing.T, cache *sessionCache, region *string, role config.Role) {
-			iface := cache.GetAPIGateway(region, role)
+		t, "Account",
+		func(t *testing.T, cache *clientCache, region string, role config.Role) {
+			iface := cache.GetAccountClient(region, role)
 			if iface == nil {
 				t.Fail()
 				return
@@ -855,35 +731,30 @@ func TestSessionCacheGetAPIGateway(t *testing.T) {
 func testGetAWSClient(
 	t *testing.T,
 	name string,
-	testClientGet func(*testing.T, *sessionCache, *string, config.Role),
+	testClientGet func(*testing.T, *clientCache, string, config.Role),
 ) {
 	region := "us-east-1"
 	role := config.Role{}
 	tests := []struct {
 		descrip     string
-		cache       *sessionCache
+		cache       *clientCache
 		parallelRun bool
 	}{
 		{
 			"locks during unrefreshed parallel call",
-			&sessionCache{
+			&clientCache{
 				refreshed: false,
 				mu:        sync.Mutex{},
 				session:   mock.Session,
 				stscache: map[config.Role]stsiface.STSAPI{
 					{}: nil,
 				},
-				clients: map[config.Role]map[string]*clientCache{
+				clients: map[config.Role]map[string]*clients{
 					{}: {
-						"us-east-1": &clientCache{
-							cloudwatch:     createCloudwatchSession(mock.Session, &region, role, false, false),
-							tagging:        createTagSession(mock.Session, &region, role, false),
-							asg:            createASGSession(mock.Session, &region, role, false),
-							ec2:            createEC2Session(mock.Session, &region, role, false, false),
-							dms:            createDMSSession(mock.Session, &region, role, false, false),
-							apiGateway:     createAPIGatewaySession(mock.Session, &region, role, false, false),
-							storageGateway: createStorageGatewaySession(mock.Session, &region, role, false, false),
-							prometheus:     createPrometheusSession(mock.Session, &region, role, false, false),
+						"us-east-1": &clients{
+							cloudwatch: createCloudWatchClient(mock.Session, &region, role, false, logging.NewNopLogger()),
+							tagging:    createTaggingClient(mock.Session, &region, role, false, logging.NewNopLogger()),
+							account:    createAccountClient(logging.NewNopLogger(), createStsSession(mock.Session, role, "", false, false)),
 						},
 					},
 				},
@@ -892,25 +763,20 @@ func testGetAWSClient(
 			true,
 		},
 		{
-			"returns session if available",
-			&sessionCache{
+			"returns clients if available",
+			&clientCache{
 				refreshed: true,
 				session:   mock.Session,
 				mu:        sync.Mutex{},
 				stscache: map[config.Role]stsiface.STSAPI{
 					{}: nil,
 				},
-				clients: map[config.Role]map[string]*clientCache{
+				clients: map[config.Role]map[string]*clients{
 					{}: {
-						"us-east-1": &clientCache{
-							cloudwatch:     createCloudwatchSession(mock.Session, &region, role, false, false),
-							tagging:        createTagSession(mock.Session, &region, role, false),
-							asg:            createASGSession(mock.Session, &region, role, false),
-							ec2:            createEC2Session(mock.Session, &region, role, false, false),
-							dms:            createDMSSession(mock.Session, &region, role, false, false),
-							apiGateway:     createAPIGatewaySession(mock.Session, &region, role, false, false),
-							storageGateway: createStorageGatewaySession(mock.Session, &region, role, false, false),
-							prometheus:     createPrometheusSession(mock.Session, &region, role, false, false),
+						"us-east-1": &clients{
+							cloudwatch: createCloudWatchClient(mock.Session, &region, role, false, logging.NewNopLogger()),
+							tagging:    createTaggingClient(mock.Session, &region, role, false, logging.NewNopLogger()),
+							account:    createAccountClient(logging.NewNopLogger(), createStsSession(mock.Session, role, "", false, false)),
 						},
 					},
 				},
@@ -919,17 +785,17 @@ func testGetAWSClient(
 			false,
 		},
 		{
-			"creates a new session if not available",
-			&sessionCache{
+			"creates a new clients if not available",
+			&clientCache{
 				refreshed: true,
 				session:   mock.Session,
 				mu:        sync.Mutex{},
 				stscache: map[config.Role]stsiface.STSAPI{
 					{}: nil,
 				},
-				clients: map[config.Role]map[string]*clientCache{
+				clients: map[config.Role]map[string]*clients{
 					{}: {
-						"us-east-1": &clientCache{},
+						"us-east-1": &clients{},
 					},
 				},
 				logger: logging.NewNopLogger(),
@@ -943,9 +809,9 @@ func testGetAWSClient(
 		t.Run(name+" "+test.descrip, func(t *testing.T) {
 			t.Parallel()
 			if test.parallelRun {
-				go testClientGet(t, test.cache, &region, role)
+				go testClientGet(t, test.cache, region, role)
 			}
-			testClientGet(t, test.cache, &region, role)
+			testClientGet(t, test.cache, region, role)
 
 			if test.cache.clients[role][region] == nil {
 				t.Log("cache is nil when it should be populated")
@@ -1042,7 +908,7 @@ func TestCreateAWSSession(t *testing.T) {
 		descrip string
 	}{
 		{
-			"creates an aws session",
+			"creates an aws clients",
 		},
 	}
 
@@ -1064,31 +930,31 @@ func TestCreateStsSession(t *testing.T) {
 		stsRegion string
 	}{
 		{
-			"creates an sts session with an empty role",
+			"creates an sts clients with an empty role",
 			config.Role{},
 			"",
 		},
 		{
-			"creates an sts session with region",
+			"creates an sts clients with region",
 			config.Role{},
 			"eu-west-1",
 		},
 		{
-			"creates an sts session with an empty external id",
+			"creates an sts clients with an empty external id",
 			config.Role{
 				RoleArn: "some:arn",
 			},
 			"",
 		},
 		{
-			"creates an sts session with an empty role arn",
+			"creates an sts clients with an empty role arn",
 			config.Role{
 				ExternalID: "some-id",
 			},
 			"",
 		},
 		{
-			"creates an sts session with an sts full role",
+			"creates an sts clients with an sts full role",
 			config.Role{
 				RoleArn:    "some:arn",
 				ExternalID: "some-id",

--- a/pkg/clients/cloudwatch/client_test.go
+++ b/pkg/clients/cloudwatch/client_test.go
@@ -1,4 +1,4 @@
-package apicloudwatch
+package cloudwatch
 
 import (
 	"testing"

--- a/pkg/clients/cloudwatch/input.go
+++ b/pkg/clients/cloudwatch/input.go
@@ -1,4 +1,4 @@
-package apicloudwatch
+package cloudwatch
 
 import (
 	"strconv"

--- a/pkg/clients/tagging/filters.go
+++ b/pkg/clients/tagging/filters.go
@@ -1,4 +1,4 @@
-package apitagging
+package tagging
 
 import (
 	"context"
@@ -21,16 +21,16 @@ import (
 
 type serviceFilter struct {
 	// ResourceFunc can be used to fetch additional resources
-	ResourceFunc func(context.Context, Client, *config.Job, string) ([]*model.TaggedResource, error)
+	ResourceFunc func(context.Context, client, *config.Job, string) ([]*model.TaggedResource, error)
 
 	// FilterFunc can be used to the input resources or to drop based on some condition
-	FilterFunc func(context.Context, Client, []*model.TaggedResource) ([]*model.TaggedResource, error)
+	FilterFunc func(context.Context, client, []*model.TaggedResource) ([]*model.TaggedResource, error)
 }
 
 // serviceFilters maps a service namespace to (optional) serviceFilter
 var serviceFilters = map[string]serviceFilter{
 	"AWS/ApiGateway": {
-		FilterFunc: func(ctx context.Context, client Client, inputResources []*model.TaggedResource) ([]*model.TaggedResource, error) {
+		FilterFunc: func(ctx context.Context, client client, inputResources []*model.TaggedResource) ([]*model.TaggedResource, error) {
 			promutil.APIGatewayAPICounter.Inc()
 			var limit int64 = 500 // max number of results per page. default=25, max=500
 			const maxPages = 10
@@ -62,7 +62,7 @@ var serviceFilters = map[string]serviceFilter{
 		},
 	},
 	"AWS/AutoScaling": {
-		ResourceFunc: func(ctx context.Context, client Client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			err := client.autoscalingAPI.DescribeAutoScalingGroupsPagesWithContext(ctx, &autoscaling.DescribeAutoScalingGroupsInput{},
@@ -96,7 +96,7 @@ var serviceFilters = map[string]serviceFilter{
 	},
 	"AWS/DMS": {
 		// Append the replication instance identifier to DMS task and instance ARNs
-		FilterFunc: func(ctx context.Context, client Client, inputResources []*model.TaggedResource) ([]*model.TaggedResource, error) {
+		FilterFunc: func(ctx context.Context, client client, inputResources []*model.TaggedResource) ([]*model.TaggedResource, error) {
 			if len(inputResources) == 0 {
 				return inputResources, nil
 			}
@@ -149,7 +149,7 @@ var serviceFilters = map[string]serviceFilter{
 		},
 	},
 	"AWS/EC2Spot": {
-		ResourceFunc: func(ctx context.Context, client Client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			err := client.ec2API.DescribeSpotFleetRequestsPagesWithContext(ctx, &ec2.DescribeSpotFleetRequestsInput{},
@@ -182,7 +182,7 @@ var serviceFilters = map[string]serviceFilter{
 		},
 	},
 	"AWS/Prometheus": {
-		ResourceFunc: func(ctx context.Context, client Client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			err := client.prometheusSvcAPI.ListWorkspacesPagesWithContext(ctx, &prometheusservice.ListWorkspacesInput{},
@@ -215,7 +215,7 @@ var serviceFilters = map[string]serviceFilter{
 		},
 	},
 	"AWS/StorageGateway": {
-		ResourceFunc: func(ctx context.Context, client Client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			err := client.storageGatewayAPI.ListGatewaysPagesWithContext(ctx, &storagegateway.ListGatewaysInput{},
@@ -255,7 +255,7 @@ var serviceFilters = map[string]serviceFilter{
 		},
 	},
 	"AWS/TransitGateway": {
-		ResourceFunc: func(ctx context.Context, client Client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			err := client.ec2API.DescribeTransitGatewayAttachmentsPagesWithContext(ctx, &ec2.DescribeTransitGatewayAttachmentsInput{},

--- a/pkg/clients/tagging/filters_test.go
+++ b/pkg/clients/tagging/filters_test.go
@@ -1,4 +1,4 @@
-package apitagging
+package tagging
 
 import (
 	"context"
@@ -33,13 +33,13 @@ func TestValidServiceNames(t *testing.T) {
 func TestApiGatewayFilterFunc(t *testing.T) {
 	tests := []struct {
 		name            string
-		iface           Client
+		iface           client
 		inputResources  []*model.TaggedResource
 		outputResources []*model.TaggedResource
 	}{
 		{
 			"api gateway resources skip stages",
-			Client{
+			client{
 				apiGatewayAPI: apiGatewayClient{
 					getRestApisOutput: &apigateway.GetRestApisOutput{
 						Items: []*apigateway.RestApi{
@@ -132,19 +132,19 @@ func TestApiGatewayFilterFunc(t *testing.T) {
 func TestDMSFilterFunc(t *testing.T) {
 	tests := []struct {
 		name            string
-		iface           Client
+		iface           client
 		inputResources  []*model.TaggedResource
 		outputResources []*model.TaggedResource
 	}{
 		{
 			"empty input resources",
-			Client{},
+			client{},
 			[]*model.TaggedResource{},
 			[]*model.TaggedResource{},
 		},
 		{
 			"replication tasks and instances",
-			Client{
+			client{
 				dmsAPI: dmsClient{
 					describeReplicationInstancesOutput: &databasemigrationservice.DescribeReplicationInstancesOutput{
 						ReplicationInstances: []*databasemigrationservice.ReplicationInstance{

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/session"
 )
 
 // Metrics is a slice of prometheus metrics specific to the scraping process such API call counters
@@ -121,7 +121,7 @@ func EnableFeatureFlag(flags ...string) OptionsFunc {
 // - `config`: this is the struct representation of the configuration defined in top-level configuration
 // - `logger`: any implementation of the `Logger` interface
 // - `registry`: any prometheus compatible registry where scraped AWS metrics will be written
-// - `cache`: any implementation of the `SessionCache`
+// - `cache`: any implementation of the `ClientCache`
 // - `optFuncs`: (optional) any number of options funcs
 //
 // You can pre-register any of the default metrics with the provided `registry` if you want them
@@ -133,7 +133,7 @@ func UpdateMetrics(
 	logger logging.Logger,
 	cfg config.ScrapeConf,
 	registry *prometheus.Registry,
-	cache session.SessionCache,
+	cache clients.ClientCache,
 	optFuncs ...OptionsFunc,
 ) error {
 	options := defaultOptions

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -10,14 +10,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/apicloudwatch"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/apitagging"
+	cloudwatch_client "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/tagging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job/associator"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job/maxdimassociator"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/session"
 )
 
 type resourceAssociator interface {
@@ -26,51 +25,13 @@ type resourceAssociator interface {
 
 func runDiscoveryJob(
 	ctx context.Context,
-	logger logging.Logger,
-	cache session.SessionCache,
-	metricsPerQuery int,
 	job *config.Job,
 	region string,
-	role config.Role,
-	account *string,
-	exportedTags model.ExportedTagsOnMetrics,
-	taggingAPIConcurrency int,
-	cloudwatchAPIConcurrency int,
-) ([]*model.TaggedResource, []*model.CloudwatchData) {
-	clientCloudwatch := apicloudwatch.NewLimitedConcurrencyClient(
-		apicloudwatch.NewClient(
-			logger,
-			cache.GetCloudwatch(&region, role),
-		),
-		cloudwatchAPIConcurrency,
-	)
-
-	clientTag := apitagging.NewLimitedConcurrencyClient(
-		apitagging.NewClient(
-			logger,
-			cache.GetTagging(&region, role),
-			cache.GetASG(&region, role),
-			cache.GetAPIGateway(&region, role),
-			cache.GetEC2(&region, role),
-			cache.GetDMS(&region, role),
-			cache.GetPrometheus(&region, role),
-			cache.GetStorageGateway(&region, role),
-		),
-		taggingAPIConcurrency)
-
-	return scrapeDiscoveryJobUsingMetricData(ctx, job, region, account, exportedTags, clientTag, clientCloudwatch, metricsPerQuery, job.RoundingPeriod, logger)
-}
-
-func scrapeDiscoveryJobUsingMetricData(
-	ctx context.Context,
-	job *config.Job,
-	region string,
-	accountID *string,
+	accountID string,
 	tagsOnMetrics model.ExportedTagsOnMetrics,
-	clientTag apitagging.TaggingClient,
-	clientCloudwatch apicloudwatch.CloudWatchClient,
+	clientTag tagging.Client,
+	clientCloudwatch cloudwatch_client.Client,
 	metricsPerQuery int,
-	roundingPeriod *int64,
 	logger logging.Logger,
 ) ([]*model.TaggedResource, []*model.CloudwatchData) {
 	logger.Debug("Get tagged resources")
@@ -79,7 +40,7 @@ func scrapeDiscoveryJobUsingMetricData(
 
 	resources, err := clientTag.GetResources(ctx, job, region)
 	if err != nil {
-		if errors.Is(err, apitagging.ErrExpectedToFindResources) {
+		if errors.Is(err, tagging.ErrExpectedToFindResources) {
 			logger.Error(err, "No tagged resources made it through filtering")
 		} else {
 			logger.Error(err, "Couldn't describe resources")
@@ -117,7 +78,7 @@ func scrapeDiscoveryJobUsingMetricData(
 				end = metricDataLength
 			}
 			input := getMetricDatas[i:end]
-			filter := apicloudwatch.CreateGetMetricDataInput(input, &svc.Namespace, length, job.Delay, roundingPeriod, logger)
+			filter := cloudwatch_client.CreateGetMetricDataInput(input, &svc.Namespace, length, job.Delay, job.RoundingPeriod, logger)
 			data := clientCloudwatch.GetMetricData(ctx, filter)
 			if data != nil {
 				getMetricDataOutput[n] = data
@@ -190,9 +151,9 @@ func getMetricDataForQueries(
 	discoveryJob *config.Job,
 	svc *config.ServiceConfig,
 	region string,
-	accountID *string,
+	accountID string,
 	tagsOnMetrics model.ExportedTagsOnMetrics,
-	clientCloudwatch apicloudwatch.CloudWatchClient,
+	clientCloudwatch cloudwatch_client.Client,
 	resources []*model.TaggedResource,
 ) []*model.CloudwatchData {
 	mux := &sync.Mutex{}
@@ -271,7 +232,7 @@ func getFilteredMetricDatas(
 	ctx context.Context,
 	logger logging.Logger,
 	region string,
-	accountID *string,
+	accountID string,
 	namespace string,
 	customTags []model.Tag,
 	tagsOnMetrics model.ExportedTagsOnMetrics,
@@ -318,7 +279,7 @@ func getFilteredMetricDatas(
 				CustomTags:             customTags,
 				Dimensions:             cwMetric.Dimensions,
 				Region:                 &region,
-				AccountID:              accountID,
+				AccountID:              &accountID,
 				Period:                 m.Period,
 			})
 		}

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -17,7 +17,7 @@ import (
 func Test_getFilteredMetricDatas(t *testing.T) {
 	type args struct {
 		region                    string
-		accountID                 *string
+		accountID                 string
 		namespace                 string
 		customTags                []model.Tag
 		tagsOnMetrics             model.ExportedTagsOnMetrics
@@ -36,7 +36,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			"additional dimension",
 			args{
 				region:     "us-east-1",
-				accountID:  aws.String("123123123123"),
+				accountID:  "123123123123",
 				namespace:  "efs",
 				customTags: nil,
 				tagsOnMetrics: map[string][]string{
@@ -127,7 +127,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			"ec2",
 			args{
 				region:     "us-east-1",
-				accountID:  aws.String("123123123123"),
+				accountID:  "123123123123",
 				namespace:  "ec2",
 				customTags: nil,
 				tagsOnMetrics: map[string][]string{
@@ -210,7 +210,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			"kafka",
 			args{
 				region:     "us-east-1",
-				accountID:  aws.String("123123123123"),
+				accountID:  "123123123123",
 				namespace:  "kafka",
 				customTags: nil,
 				tagsOnMetrics: map[string][]string{
@@ -293,7 +293,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			"alb",
 			args{
 				region:                    "us-east-1",
-				accountID:                 aws.String("123123123123"),
+				accountID:                 "123123123123",
 				namespace:                 "alb",
 				customTags:                nil,
 				tagsOnMetrics:             nil,

--- a/pkg/job/scrape.go
+++ b/pkg/job/scrape.go
@@ -4,19 +4,17 @@ import (
 	"context"
 	"sync"
 
-	"github.com/aws/aws-sdk-go/service/sts"
-
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/session"
 )
 
 func ScrapeAwsData(
 	ctx context.Context,
 	logger logging.Logger,
 	cfg config.ScrapeConf,
-	cache session.SessionCache,
+	cache clients.ClientCache,
 	metricsPerQuery int,
 	cloudWatchAPIConcurrency int,
 	taggingAPIConcurrency int,
@@ -39,14 +37,14 @@ func ScrapeAwsData(
 				go func(discoveryJob *config.Job, region string, role config.Role) {
 					defer wg.Done()
 					jobLogger := logger.With("job_type", discoveryJob.Type, "region", region, "arn", role.RoleArn)
-					result, err := cache.GetSTS(role).GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
-					if err != nil || result.Account == nil {
+					accountID, err := cache.GetAccountClient(region, role).GetAccount(ctx)
+					if err != nil {
 						jobLogger.Error(err, "Couldn't get account Id")
 						return
 					}
-					jobLogger = jobLogger.With("account", *result.Account)
+					jobLogger = jobLogger.With("account", accountID)
 
-					resources, metrics := runDiscoveryJob(ctx, jobLogger, cache, metricsPerQuery, discoveryJob, region, role, result.Account, cfg.Discovery.ExportedTagsOnMetrics, taggingAPIConcurrency, cloudWatchAPIConcurrency)
+					resources, metrics := runDiscoveryJob(ctx, discoveryJob, region, accountID, cfg.Discovery.ExportedTagsOnMetrics, cache.GetTaggingClient(region, role, taggingAPIConcurrency), cache.GetCloudwatchClient(region, role, cloudWatchAPIConcurrency), metricsPerQuery, logger)
 					if len(metrics) != 0 {
 						mux.Lock()
 						awsInfoData = append(awsInfoData, resources...)
@@ -65,14 +63,14 @@ func ScrapeAwsData(
 				go func(staticJob *config.Static, region string, role config.Role) {
 					defer wg.Done()
 					jobLogger := logger.With("static_job_name", staticJob.Name, "region", region, "arn", role.RoleArn)
-					result, err := cache.GetSTS(role).GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
-					if err != nil || result.Account == nil {
+					accountID, err := cache.GetAccountClient(region, role).GetAccount(ctx)
+					if err != nil {
 						jobLogger.Error(err, "Couldn't get account Id")
 						return
 					}
-					jobLogger = jobLogger.With("account", *result.Account)
+					jobLogger = jobLogger.With("account", accountID)
 
-					metrics := runStaticJob(ctx, jobLogger, cache, region, role, staticJob, result.Account, cloudWatchAPIConcurrency)
+					metrics := runStaticJob(ctx, staticJob, region, accountID, cache.GetCloudwatchClient(region, role, cloudWatchAPIConcurrency), logger)
 
 					mux.Lock()
 					cwData = append(cwData, metrics...)
@@ -91,14 +89,14 @@ func ScrapeAwsData(
 				go func(customNamespaceJob *config.CustomNamespace, region string, role config.Role) {
 					defer wg.Done()
 					jobLogger := logger.With("custom_metric_namespace", customNamespaceJob.Namespace, "region", region, "arn", role.RoleArn)
-					result, err := cache.GetSTS(role).GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
-					if err != nil || result.Account == nil {
+					accountID, err := cache.GetAccountClient(region, role).GetAccount(ctx)
+					if err != nil {
 						jobLogger.Error(err, "Couldn't get account Id")
 						return
 					}
-					jobLogger = jobLogger.With("account", *result.Account)
+					jobLogger = jobLogger.With("account", accountID)
 
-					metrics := runCustomNamespaceJob(ctx, jobLogger, cache, metricsPerQuery, customNamespaceJob, region, role, result.Account, cloudWatchAPIConcurrency)
+					metrics := runCustomNamespaceJob(ctx, customNamespaceJob, region, accountID, cache.GetCloudwatchClient(region, role, cloudWatchAPIConcurrency), logger, metricsPerQuery)
 
 					mux.Lock()
 					cwData = append(cwData, metrics...)


### PR DESCRIPTION
The main goal of this PR is to stop `SessionCache` from returning any aws sdk defined interfaces. 

As a part of this the name `SessionCache` stopped making sense as there's nothing session related in the interface. This caused me to rename it to `ClientCache` and move it to a new clients pkg where I centralized all the client implementations.

Related to: https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/921